### PR TITLE
Fixing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To do it, use the following command:
 
 ```sh
 > gcloud services enable deploymentmanager.googleapis.com sqladmin.googleapis.com iam.googleapis.com \
-  cloudresourcemanager.googleapis.com runtimeconfig.googleapis.com
+  cloudresourcemanager.googleapis.com runtimeconfig.googleapis.com compute.googleapis.com
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To do it, use the following command:
 ```sh
 > gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
   --member serviceAccount:$(gcloud projects describe $(gcloud config get-value project) \
-  --format="value(<projectNumber>)")@cloudservices.gserviceaccount.com --role roles/owner
+  --format="value(projectNumber)")@cloudservices.gserviceaccount.com --role roles/owner
 ```
 
 ### Google Cloud APIs


### PR DESCRIPTION
I had two issues running these instructions:
1. The compute service was not enabled on a new project
2. The [format function ](https://cloud.google.com/sdk/gcloud/reference/topic/formats)for setting projectNumber was formatted incorrectly 