### PR TITLE
Fixing Let's Encrypt service

### DIFF
--- a/virtual-machine.jinja
+++ b/virtual-machine.jinja
@@ -369,8 +369,8 @@ resources:
                   -v /var/run/docker.sock:/var/run/docker.sock:ro \
                   --name {{ LETSENCRYPT }} \
                   {{ LETSENCRYPT_IMAGE }}
-                ExecStop=-/usr/bin/docker stop {{ LETSENCRYPT_IMAGE }}
-                ExecStopPost=-/usr/bin/docker rm {{ LETSENCRYPT_IMAGE }}
+                ExecStop=-/usr/bin/docker stop {{ LETSENCRYPT }}
+                ExecStopPost=-/usr/bin/docker rm {{ LETSENCRYPT }}
                 Restart=always
 
                 [Install]


### PR DESCRIPTION
After running the service for a while eventually letsencrypt would start failing with `/run/torcx/bin/docker: Error response from daemon: Conflict. The container name "/letsencrypt" is already in use by container` and the `ExecStopPost` job would fail with `Error: No such container: jrcs/letsencrypt-nginx-proxy-companion`
This is because `docker rm` and `docker stop` use the name from docker.