### PR TITLE
closes issue #11

### DIFF
--- a/virtual-machine.jinja
+++ b/virtual-machine.jinja
@@ -182,8 +182,8 @@ resources:
                 Type=oneshot
                 ExecStart=/bin/mkdir -p /mnt/data/teamcity-server/data/lib/jdbc
                 ExecStart=/bin/wget -O /mnt/data/teamcity-server/data/lib/jdbc/mysql-socket-factory.jar \
-                  http://central.maven.org/maven2/com/google/cloud/sql/mysql-socket-factory/{{ GOOGLE_FACTORY }}/mysql-socket-factory-{{ GOOGLE_FACTORY }}.jar
-                ExecStart=/bin/wget -O pom.xml http://central.maven.org/maven2/com/google/cloud/sql/mysql-socket-factory/{{ GOOGLE_FACTORY }}/mysql-socket-factory-{{ GOOGLE_FACTORY }}.pom
+                   http://insecure.repo1.maven.org/maven2/com/google/cloud/sql/mysql-socket-factory/{{ GOOGLE_FACTORY }}/mysql-socket-factory-{{ GOOGLE_FACTORY }}.jar
+                ExecStart=/bin/wget -O pom.xml http://insecure.repo1.maven.org/maven2/com/google/cloud/sql/mysql-socket-factory/{{ GOOGLE_FACTORY }}/mysql-socket-factory-{{ GOOGLE_FACTORY }}.pom
                 ExecStart=/bin/bash -c 'docker run --rm -v "$(pwd)":/opt/maven -v /mnt/data/teamcity-server/data/lib/jdbc:/opt/maven/target/dependency -w /opt/maven maven:alpine mvn dependency:copy-dependencies && docker rmi maven:alpine'
                 ExecStart=/bin/rm pom.xml
 


### PR DESCRIPTION
closes issue #11 

The central repository moved to https. Updated to their new domain that accommodates insecure traffic.

https://blog.sonatype.com/central-repository-moving-to-https